### PR TITLE
DotNotationPointers create property fix

### DIFF
--- a/DotNotationPointers.js
+++ b/DotNotationPointers.js
@@ -83,12 +83,11 @@ Object.defineProperty(DotNotationPointer.prototype, 'val', {
             }
         }
     }, set: function(value) {
-        var info = this.propertyInfo
-        if(info.obj === undefined) { // create the path if it doesn't exist
+        if(this.propertyInfo.obj === undefined) { // create the path if it doesn't exist
             createProperty(this)
         }
 
-        info.obj[info.last] = value
+        this.propertyInfo.obj[this.propertyInfo.last] = value
     }
 })
 

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -314,6 +314,15 @@ Unit.test("mongo-parse", function(t) {
             this.eq(pointerz[2].val, 3)
             this.eq(pointerz[3].val, 4)
         })
+
+        this.test('creating properties', function() {
+          var theObject = {};
+          var pointerz = DotNotationPointers(theObject, "a.b");
+          this.eq(pointerz.length, 1);
+
+          pointerz[0].val = 1;
+          this.eq(theObject.a.b, 1);
+        });
     })
 
     this.test('mapValues', function(t) {


### PR DESCRIPTION
Creating new properties fails.

This is because createProperty creates a new propertyInfo reference but the setter function still references the old value.