### PR TITLE
npm test, document prototype-keys 

### DIFF
--- a/matches.js
+++ b/matches.js
@@ -105,7 +105,7 @@ var matches = module.exports = function(parts, document, validate) {
     if(validate !== false)
         validateDocumentObject(document)
 
-    return parts.every((part) => partMatches(part, document));
+    return parts.every(function(part) { return partMatches(part, document)});
 }
 
 function partMatches(part, document) {

--- a/matches.js
+++ b/matches.js
@@ -261,7 +261,8 @@ function mongoEqual(documentValue,queryOperand) {
 }
 
 function validateDocumentObject(document) {
-    for(var key in document) {
+
+    Object.keys(document).forEach(function(key) {
         if(key[0] === '$')
             throw new Error("Field names can't start with $")
         else if(key.indexOf('.') !== -1)
@@ -269,5 +270,6 @@ function validateDocumentObject(document) {
         else if(document[key] instanceof Object) {
             validateDocumentObject(document[key])
         }
-    }
+    });
+
 }

--- a/matches.js
+++ b/matches.js
@@ -105,15 +105,7 @@ var matches = module.exports = function(parts, document, validate) {
     if(validate !== false)
         validateDocumentObject(document)
 
-    for(var n=0; n<parts.length; n++) {
-        var part = parts[n]
-        if(!partMatches(part, document))
-            return false
-    }
-    // else
-
-    return true
-
+    return parts.every((part) => partMatches(part, document));
 }
 
 function partMatches(part, document) {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
     "deadunit":"5.0.3"
  },
  "scripts": {
+ 	"test":"node ./testProxy"
  }
 }


### PR DESCRIPTION
Hey @fresheneesz,

three little suggestions:

- 79c2c60 enable ability to run tests through: `npm test`
- ac2451c ignores prototype keys on validation by `validateDocumentObject`.
- 43878eb more readable ;)